### PR TITLE
Prevent host's node_modules from being mounted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       DB_HOST: mysql
     volumes:
       - ./backend:/app:rw
+      # prevent host's node_modules from being mounted
+      - /app/node_modules
   frontend:
     build:
       context: ./frontend


### PR DESCRIPTION
In development mode, we mount the host's `backend` source in order to watch for changes and rebuild as needed using [`nodemon`](https://nodemon.io/). Previously, the host's `node_modules` directory would overwrite the version built in the container. If the host's dependencies were out-of-sync with those listed in `package.json`, it could cause problems when running the container. To avoid potential problems, we now ensure the container's `node_modules` is always used.